### PR TITLE
update EventService and create get-academic-year for parent

### DIFF
--- a/app/Http/Controllers/Api/ExamController.php
+++ b/app/Http/Controllers/Api/ExamController.php
@@ -14,12 +14,14 @@ class ExamController extends BaseApiController
         $student= $request->attributes->get('current_student');
         $date= $request->query('date');
         $search= $request->query('search');
-        return $this->success($this->service->getSubject($student, $date, $search));
+        $academicYearId= $request->query('academicYearId');
+        return $this->success($this->service->getSubject($student, $date, $search, $academicYearId));
     }
 
     public function getExam(Request $request, int $subject){
         $student= $request->attributes->get('current_student');
         $date=$request->query('date');
-        return $this->success($this->service->getExam($student, $date, $subject));
+        $academicYearId= $request->query('academicYearId');
+        return $this->success($this->service->getExam($student, $date, $subject, $academicYearId));
     }
 }

--- a/app/Http/Controllers/Api/ParentController.php
+++ b/app/Http/Controllers/Api/ParentController.php
@@ -4,10 +4,12 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\ChangePasswordRequest;
+use App\Http\Resources\AcademicYearResource;
 use App\Http\Resources\AnnouncementResource;
 use App\Http\Resources\StudentResource;
 use App\Http\Resources\SubjectResource;
 use App\Http\Resources\UserResource;
+use App\Models\AcademicYear;
 use App\Models\Announcement;
 use App\Models\Student;
 use App\Models\Subject;
@@ -46,6 +48,12 @@ class ParentController extends BaseApiController
     {
         $data= $this->service->getAnnouncements($id, $request->search);
 
+        if ($id) {
+            return $this->success([
+               AnnouncementResource::make(Announcement::findOrFail($id))
+            ]);
+        }
+    
         return $this->success([
             'current_page' => $data['current_page'],
             'last_page' => $data['last_page'],
@@ -77,8 +85,9 @@ class ParentController extends BaseApiController
         return $this->success($this->service->getSubjectSchedule($student));
     }
 
-    public function getEventDate(string $date){
-        return $this->success($this->service->getEventDate($date));
+    public function getEventDate(Request $request,string $date){
+        $student = $request->attributes->get('current_student');
+        return $this->success($this->service->getEventDate($student,$date));
     }
 
     public function getEventSchedule(Request $request, ){
@@ -112,5 +121,9 @@ class ParentController extends BaseApiController
         return $this->resource(
             SubjectResource::collection(Subject::get())
         );
+    }
+
+    public function getAcademicYear(){
+        return $this->resource(AcademicYearResource::collection(AcademicYear::get()));
     }
 }

--- a/app/Http/Resources/AcademicYearResource.php
+++ b/app/Http/Resources/AcademicYearResource.php
@@ -5,7 +5,7 @@ namespace App\Http\Resources;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class AnnouncementResource extends JsonResource
+class AcademicYearResource extends JsonResource
 {
     /**
      * Transform the resource into an array.
@@ -15,11 +15,12 @@ class AnnouncementResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
-            "id"=> $this->id,
+            'id' => $this->id,
+            'start_year' => $this->start_year,
             'title' => $this->title,
-            'content' => $this->content,
-            'short_content' => $this->short_content,
-            'attachments' => $this->attachments->pluck('url'),
+            'status'=> $this->status,
+            'attendance_mode' => $this->attendance_mode,
+            'note' => $this->note
         ];
     }
 }

--- a/app/Services/ExamService.php
+++ b/app/Services/ExamService.php
@@ -10,10 +10,15 @@ use Carbon\Carbon;
 
 class ExamService
 {
-    public function getSubject($student, $date, $search){
+    public function getSubject($student, $date, $search, $academicYearId){
         $subjectQuery = Subject::query();
         $examQuery=ExamAssignment::query();
         $examQuery->where('student_id', $student->id);
+        if ($academicYearId) {
+            $examQuery->whereHas('exam', function($q) use ($academicYearId) {
+                $q->where('academic_year_id', $academicYearId);
+            });
+        }
         if ($date) {
             $parsedDate = Carbon::parse($date);
             $examQuery->whereHas('exam', function($q) use ($parsedDate) {
@@ -42,12 +47,17 @@ class ExamService
         ];
     }
 
-    public function getExam($student, $date, $subject){
+    public function getExam($student, $date, $subject, $academicYearId){
         $query=ExamAssignment::query();
         $query->where('student_id', $student->id);
         $query->whereHas('exam', function($q) use ($subject) {
             $q->where('subject_id', $subject);
         });
+        if ($academicYearId) {
+            $query->whereHas('exam', function($q) use ($academicYearId) {
+                $q->where('academic_year_id', $academicYearId);
+            });
+        }
         if ($date) {
             $parsedDate = Carbon::parse($date);
             $query->whereHas('exam', function($q) use ($parsedDate) {
@@ -70,7 +80,7 @@ class ExamService
             ];
         }
 
-        $subject=Subject::find($subject)->value('name');
+        $subject=Subject::where('id',$subject)->value('name');
         $totalUlangan=$exams->count();
         $totalNilai=$exams->sum('score');
         $rataRata=$totalNilai/$totalUlangan;

--- a/app/Services/TaskService.php
+++ b/app/Services/TaskService.php
@@ -70,8 +70,8 @@ class TaskService
             'title'=>$task->task->title,
             'description'=>$task->task->description,
             'attachments'=>$attachments,
-            'due_date'=>$task->task->due_date,
-            'due_time'=>$task->task->due_time,
+            'due_date'=>Carbon::parse($task->task->due_date)->format('Y-m-d'),
+                'due_time'=>Carbon::parse($task->task->due_time)->format('H:i'),
             'created_at'=>$task->task->created_at
         ];
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -38,6 +38,8 @@ class DatabaseSeeder extends Seeder
                 EventParticipantSeeder::class,
                 EventAttendanceSeeder::class,
                 CustomDayOffSeeder::class,
+                ExamSeeder::class,
+                TaskSeeder::class
             ]);
 
             DB::commit();

--- a/database/seeders/EventAttendanceSeeder.php
+++ b/database/seeders/EventAttendanceSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\AcademicYear;
 use App\Models\Event;
 use App\Models\EventAttendance;
+use App\Models\EventParticipant;
 use Carbon\Carbon;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
@@ -16,30 +17,128 @@ class EventAttendanceSeeder extends Seeder
      */
     public function run(): void
     {
+        // Get active academic year
         $academicYear = AcademicYear::where('status', 'active')->first();
-        $events = Event::all();
+        
+        if (!$academicYear) {
+            $this->command->error('No active academic year found!');
+            return;
+        }
+
+        // Get all events with their participants
+        $events = Event::with('participants')->get();
 
         foreach ($events as $event) {
-            $participants = $event->participants;
-            $statuses = ['present', 'present_in_tolerance', 'alpha', 'late'];
+            // Skip future events (no attendance yet)
+            if ($event->start_date > Carbon::today()) {
+                continue;
+            }
 
-            foreach ($participants as $participant) {
-                $status = $statuses[array_rand($statuses)];
+            foreach ($event->participants as $participant) {
+                // Determine attendance status with realistic probabilities
+                $status = $this->determineAttendanceStatus($event);
+                
+                // Generate realistic clock times based on status
+                $clockTimes = $this->generateClockTimes($event, $status);
 
-                $attendance = EventAttendance::create([
+                EventAttendance::create([
                     'student_id' => $participant->student_id,
                     'event_id' => $event->id,
                     'academic_year_id' => $academicYear->id,
-                    'submit_date' => now(),
-                    'clock_in_hour' => $status === 'present_in_tolerance'
-                        ? Carbon::parse($event->start_hour)->addMinutes(rand(0, 5))
-                        : Carbon::parse($event->start_hour),
-                    'clock_out_hour' => Carbon::parse($event->end_hour)->addMinutes(rand(0, 10)),
+                    'submit_date' => $event->start_date,
+                    'clock_in_hour' => $clockTimes['clock_in'],
+                    'clock_out_hour' => $clockTimes['clock_out'],
                     'status' => $status,
-                    'minutes_of_late' => $status === 'present' ? null : rand(0, 15),
-                    'note' => $status !== 'present' ? 'Alasan: ' . fake()->sentence() : null,
+                    'minutes_of_late' => $clockTimes['minutes_late'],
+                    'note' => $this->generateNote($status),
                 ]);
             }
         }
+
+        $this->command->info('Successfully seeded event attendances!');
+    }
+
+    /**
+     * Determine realistic attendance status with probabilities
+     */
+    protected function determineAttendanceStatus(Event $event): string
+    {
+        $probabilities = [
+            'present' => 70,         // 70% chance
+            'present_in_tolerance' => 15, // 15% chance
+            'late' => 10,            // 10% chance
+            'alpha' => 5             // 5% chance
+        ];
+
+        $random = rand(1, 100);
+        $cumulative = 0;
+
+        foreach ($probabilities as $status => $probability) {
+            $cumulative += $probability;
+            if ($random <= $cumulative) {
+                return $status;
+            }
+        }
+
+        return 'present'; // default
+    }
+
+    /**
+     * Generate realistic clock times based on status
+     */
+    protected function generateClockTimes(Event $event, string $status): array
+    {
+        $start = Carbon::parse($event->start_hour);
+        $end = Carbon::parse($event->end_hour);
+
+        return match ($status) {
+            'present' => [
+                'clock_in' => $start->copy()->subMinutes(rand(0, 30)), // Early or on time
+                'clock_out' => $end->copy()->addMinutes(rand(0, 30)),
+                'minutes_late' => null
+            ],
+            'present_in_tolerance' => [
+                'clock_in' => $start->copy()->addMinutes(rand(1, 15)),
+                'clock_out' => $end->copy()->addMinutes(rand(0, 30)),
+                'minutes_late' => rand(1, 15)
+            ],
+            'late' => [
+                'clock_in' => $start->copy()->addMinutes(rand(16, 120)),
+                'clock_out' => $end->copy()->addMinutes(rand(0, 60)),
+                'minutes_late' => rand(16, 120)
+            ],
+            'alpha' => [
+                'clock_in' => $start->copy()->format('H:i:s'), // Atau waktu default
+                'clock_out' => $end->copy()->format('H:i:s'),  // Atau waktu default
+                'minutes_late' => null
+            ],
+            default => [
+                'clock_in' => $start,
+                'clock_out' => $end,
+                'minutes_late' => null
+            ]
+        };
+    }
+
+    /**
+     * Generate appropriate notes based on status
+     */
+    protected function generateNote(string $status): ?string
+    {
+        return match ($status) {
+            'present' => null,
+            'present_in_tolerance' => 'Datang terlambat dalam batas toleransi',
+            'late' => fake()->randomElement([
+                'Terjadi kemacetan di jalan',
+                'Kendaraan bermasalah',
+                'Ada urusan keluarga mendadak'
+            ]),
+            'alpha' => fake()->randomElement([
+                'Sakit',
+                'Izin orang tua',
+                'Tidak ada kabar'
+            ]),
+            default => null
+        };
     }
 }

--- a/database/seeders/EventSeeder.php
+++ b/database/seeders/EventSeeder.php
@@ -18,7 +18,8 @@ class EventSeeder extends Seeder
         Event::create([
             'name' => 'Seminar Pendidikan Karakter',
             'description' => 'Seminar untuk meningkatkan karakter siswa',
-            'date' => Carbon::now()->subDays(2),
+            'start_date' => Carbon::now()->subDays(2),
+            'end_date' => Carbon::now()->subDays(1),
             'start_hour' => '08:00:00',
             'end_hour' => '12:00:00',
         ]);
@@ -27,7 +28,8 @@ class EventSeeder extends Seeder
         Event::create([
             'name' => 'Workshop Kreativitas',
             'description' => 'Workshop untuk mengembangkan kreativitas siswa',
-            'date' => Carbon::today(),
+            'start_date' => Carbon::today(),
+            'end_date' => Carbon::now()->addDays(3),
             'start_hour' => '10:00:00',
             'end_hour' => '14:00:00',
         ]);
@@ -36,7 +38,8 @@ class EventSeeder extends Seeder
         Event::create([
             'name' => 'Lomba Cerdas Cermat',
             'description' => 'Lomba antar kelas untuk meningkatkan pengetahuan umum',
-            'date' => Carbon::now()->addDays(7),
+            'start_date' => Carbon::now()->addDays(7),
+            'end_date'=>Carbon::now()->addDays(10),
             'start_hour' => '09:00:00',
             'end_hour' => '15:00:00',
         ]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -104,6 +104,7 @@ Route::prefix('parent')->middleware(['auth:sanctum', 'parent', ])->controller(Pa
         Route::get('/subject-schedule', 'getSubjectSchedule');
         Route::get('/event-date/{date}', 'getEventDate');
         Route::get('/event-schedule', 'getEventSchedule');
+        Route::get('/get-academic-year', 'getAcademicYear');
         Route::prefix('attendance')->group(function (){
             Route::get('/', 'todayAttendance');
             Route::prefix('history')->group(function () {


### PR DESCRIPTION
API Update
- Teacher
1. 

- Parent
1. get-academic-year (baru) 

2. get-exams (update) = sudah ada contoh response nya, dan ada filter academicYear
https://trello.com/c/XusxTTfe/84-get-exams

3. get-subject-exam (update) = memberi filter date (Y-m), dan filter academic-year
https://trello.com/c/KXqIqbpt/83-get-subject-exams

4. get-task-details (update) = memperbaiki format due_date dan due_time
https://trello.com/c/bosJa2lb/73-detail-task

5. get-event-date (update) = mereturn start_date dan end_date dan jika history absensi event di filter berdasarkan event date akan muncul
https://trello.com/c/OwNjKe9d/72-riwayat-event

6. get-detail-event (update) = respon sudah diperbaiki 
https://trello.com/c/bxAGggKF/71-get-detail-pengumuman

7. EventSeeder (update) = memperbaiki date menjadi start_date dan end_date (php artisan db:seed --class=EventSeeder)

8. EventAttendanceSeeder (update) = memperbaiki agar absensi yang digenerate yang hanya event yang sudah berlalu atau sedang berlangusung (php artisan db:seed --class=EventAttendanceSeeder)